### PR TITLE
add a region-based constructor which uses the aws-region crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ log = "0.4.20"
 serde = { version = "1.0.188", features = ["derive"] }
 http = "0.2.9"
 quick-xml = { version = "0.30.0", features = ["serialize", "serde-types", "serde"] }
+aws-region = { version = "0.25.0", optional=true }
 
 [dev-dependencies]
 insta = "1.32.0"
@@ -31,3 +32,4 @@ uuid = { version = "1.4.1", features = ["v4"] }
 [features]
 default = ["json"]
 json = ["ureq/json"]
+aws_region = ["aws-region"]

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -43,6 +43,24 @@ impl Bucket {
         Builder::new(url)
     }
 
+    /// Create a new [`Builder`] from a `Region`.
+    /// It's currently missing its key and secret.
+    ///
+    /// # Example
+    /// ```
+    /// use strois::Builder;
+    ///
+    /// let bucket = Builder::new(awsregion::Region::UsEast1)?
+    ///     .key("minioadmin")
+    ///     .secret("minioadmin")
+    ///     .bucket("tamo");
+    /// # Ok::<(), strois::Error>(())
+    /// ```
+    #[cfg(feature="aws-region")]
+    pub fn region_builder(region: impl AsRef<awsregion::Region>) -> Builder<MissingCred> {
+        Builder::new_region(region)
+    }
+
     /// Create a new bucket.
     /// /!\ this method doesn't create the bucket on S3. See [`Self::create`] for that.
     pub fn new(client: Client, bucket: impl Into<String>, url_style: UrlStyle) -> Result<Self> {

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -50,14 +50,14 @@ impl Bucket {
     /// ```
     /// use strois::Builder;
     ///
-    /// let bucket = Builder::new(awsregion::Region::UsEast1)?
+    /// let bucket = Builder::new("us-east-1".parse()?)?
     ///     .key("minioadmin")
     ///     .secret("minioadmin")
     ///     .bucket("tamo");
     /// # Ok::<(), strois::Error>(())
     /// ```
     #[cfg(feature="aws-region")]
-    pub fn region_builder(region: impl AsRef<awsregion::Region>) -> Builder<MissingCred> {
+    pub fn region_builder(region: awsregion::Region) -> Builder<MissingCred> {
         Builder::new_region(region)
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -125,10 +125,10 @@ impl Builder<MissingCred> {
     /// ```
     ///
     #[cfg(feature="aws-region")]
-    pub fn new_region(region: impl AsRef<awsregion::Region>) -> Self {
+    pub fn new_region(region: awsregion::Region) -> Self {
         Self {
-            addr: format!("{}://{}", region.as_ref().scheme(), region.as_ref().endpoint()).parse().unwrap(),
-            region: Some(region.as_ref().to_string()),
+            addr: format!("{}://{}", region.scheme(), region.endpoint()).parse().unwrap(),
+            region: Some(region.to_string()),
             cred: MissingCred,
             url_style: None,
             token: None,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -81,6 +81,63 @@ impl Builder<MissingCred> {
         })
     }
 
+    /// Create a new `Builder` based on an AWS region
+    /// It's currently missing its key and secret.
+    ///
+    /// # Example
+    /// ```
+    /// use strois::Builder;
+    ///
+    /// let client = Builder::new_region(awsregion::Region::UsEast1)
+    ///     .key("minioadmin")
+    ///     .secret("minioadmin")
+    ///     .client();
+    /// # Ok::<(), strois::Error>(())
+    /// ```
+    ///
+    /// If you try to call `.client()` before setting the key and secret it won't work.
+    /// ```compile_fail
+    /// use strois::Builder;
+    ///
+    /// let client = Builder::new_region(awsregion::Region::UsEast1)
+    ///     .client();
+    /// # Ok::<(), strois::Error>(())
+    /// ```
+    ///
+    /// But if you only forgot the secret it should panic as well:
+    /// ```compile_fail
+    /// use strois::Builder;
+    ///
+    /// let client = Builder::new_region(awsregion::Region::UsEast1)
+    ///     .secret("minioadmin")
+    ///     .client();
+    /// # Ok::<(), strois::Error>(())
+    /// ```
+    ///
+    /// Same for the key:
+    /// ```compile_fail
+    /// use strois::Builder;
+    ///
+    /// let client = Builder::new_region(awsregion::Region::UsEast1)
+    ///     .key("minioadmin")
+    ///     .client();
+    /// # Ok::<(), strois::Error>(())
+    /// ```
+    ///
+    #[cfg(feature="aws-region")]
+    pub fn new_region(region: impl AsRef<awsregion::Region>) -> Self {
+        Self {
+            addr: format!("{}://{}", region.as_ref().scheme(), region.as_ref().endpoint()).parse().unwrap(),
+            region: Some(region.as_ref().to_string()),
+            cred: MissingCred,
+            url_style: None,
+            token: None,
+            actions_expires_in: None,
+            timeout: None,
+            multipart_size: None,
+        }
+    }
+
     /// Set the key in the `Builder`.
     ///
     /// # Example

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,6 +36,25 @@ impl Client {
         Builder::new(url)
     }
 
+    /// Create a new [`Builder`].
+    /// It's currently missing its key and secret.
+    ///
+    /// # Example
+    /// ```
+    /// use strois::Client;
+    ///
+    /// let client = Builder::builder_region(awsregion::Region::UsEast1)
+    ///     .key("minioadmin")
+    ///     .secret("minioadmin")
+    ///     .client();
+    /// # Ok::<(), strois::Error>(())
+    /// ```
+    ///
+    #[cfg(feature="aws-region")]
+    pub fn builder_region(region: impl AsRef<awsregion::Region>) -> Builder<MissingCred> {
+        Builder::new_region(region)
+    }
+
     /// /!\ Does not not create the bucket on S3, only instanciates a `Bucket` object
     pub fn bucket(&self, name: impl Into<String>) -> Result<Bucket> {
         Bucket::new(self.clone(), name, self.url_style)

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,9 +23,9 @@ impl Client {
     ///
     /// # Example
     /// ```
-    /// use strois::Builder;
+    /// use strois::Client;
     ///
-    /// let client = Builder::new("http://localhost:9000")?
+    /// let client = Client::builder_region("http://localhost:9000")?
     ///     .key("minioadmin")
     ///     .secret("minioadmin")
     ///     .client();

--- a/src/client.rs
+++ b/src/client.rs
@@ -51,7 +51,7 @@ impl Client {
     /// ```
     ///
     #[cfg(feature="aws-region")]
-    pub fn builder_region(region: impl AsRef<awsregion::Region>) -> Builder<MissingCred> {
+    pub fn builder_region(region: awsregion::Region) -> Builder<MissingCred> {
         Builder::new_region(region)
     }
 


### PR DESCRIPTION
# Pull Request

## Related issue
Does not fix an issue

## What does this PR do?
- Makes it so you don't need to determine the URL if you only know the name of the AWS region

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [×] Have you made sure that the title is accurate and descriptive of the changes?

